### PR TITLE
Add projects section and navigation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,15 @@
     .pill{display:inline-block;padding:8px 12px;border-radius:999px;font-size:12px;font-weight:800;letter-spacing:.3px;background:rgba(14,165,233,.12);color:#7dd3fc;border:1px solid rgba(14,165,233,.35)}
     .stack{display:flex;flex-wrap:wrap;gap:10px}
 
+    /* ===== Projects ===== */
+      .project-card{
+        display:flex;
+        flex-direction:column;
+        gap:12px;
+        height:100%;
+      }
+      .project-card a{margin-top:auto}
+
     /* ===== Roadmap timeline ===== */
     .roadmap{position:relative}
     .roadmap-canvas{position:relative}
@@ -74,7 +83,8 @@
     .roadcard.card{border-radius:20px}
     @media(min-width:768px){
       .roadmap-svg{display:block;position:absolute;inset:0;pointer-events:none}
-      .roadmap-canvas{height:1600px}
+      /* extra height prevents overlap with following Projects section */
+      .roadmap-canvas{height:2000px}
       .roadcard{position:absolute;width:48%}
       .road-left{left:2%}
       .road-right{right:2%}
@@ -102,6 +112,7 @@
       <div class="links">
         <a href="#intro">Intro</a>
         <a href="#about">About</a>
+        <a href="#projects">Projects</a>
         <a href="#skills">Skills</a>
         <a href="#contact">Contact</a>
       </div>
@@ -161,7 +172,7 @@
       <h2 class="reveal">About — a model that keeps learning</h2>
       <div class="roadmap-canvas">
         <svg viewBox="0 0 100 200" preserveAspectRatio="xMinYMin meet" class="roadmap-svg">
-          <path d="M 50 0 C 30 25, 70 50, 50 75 S 30 125, 50 150 S 70 175, 50 200" fill="none" stroke="#238636" stroke-width="2" stroke-linecap="round" stroke-dasharray="1, 5" />
+          <path d="M 50 0 L 50 200" fill="none" stroke="#238636" stroke-width="2" stroke-linecap="round" stroke-dasharray="1, 5" />
           <circle cx="50" cy="0" r="1.5" fill="#56d46d" />
           <circle cx="50" cy="40" r="1.5" fill="#56d46d" />
           <circle cx="50" cy="80" r="1.5" fill="#56d46d" />
@@ -172,27 +183,49 @@
         <article class="card roadcard road-left" style="top:0%">
           <h3>First Pass: Computer Science Foundations</h3>
           <p>Computer Science taught me to think like a builder—hardware bits, software stacks, and the habit of continuous learning.</p>
-          <img class="roadimg" src="https://placehold.co/140x140/238636/0d1117?text=CS" alt="CS" style="top:-14px; left:-14px;" />
+          <img class="roadimg" src="https://placehold.co/140x140/238636/0d1117?text=CS" alt="CS" style="top:-14px; right:-14px;" />
         </article>
-        <article class="card roadcard road-right" style="top:22%">
+        <article class="card roadcard road-right" style="top:20%">
           <h3>Feature Engineering: Internships</h3>
           <p>ITC (manufacturing), HighRadius (fintech), and Novartis (supply chain). Different sectors, same goal: find the signal in the noise.</p>
-          <img class="roadimg" src="https://placehold.co/140x140/238636/0d1117?text=INT" alt="Internships" style="top:-14px; right:-14px;" />
+          <img class="roadimg" src="https://placehold.co/140x140/238636/0d1117?text=INT" alt="Internships" style="top:-14px; left:-14px;" />
         </article>
-        <article class="card roadcard road-left" style="top:44%">
+        <article class="card roadcard road-left" style="top:40%">
           <h3>Training the Model: Novartis</h3>
           <p>2 years in Global Supply Chain: automated Alteryx/SQL workflows, KPI dashboards, and sustainability analytics for 800+ vendors.</p>
-          <img class="roadimg" src="https://placehold.co/140x140/238636/0d1117?text=NOV" alt="Novartis" style="top:-14px; left:-14px;" />
+          <img class="roadimg" src="https://placehold.co/140x140/238636/0d1117?text=NOV" alt="Novartis" style="top:-14px; right:-14px;" />
         </article>
-        <article class="card roadcard road-right" style="top:66%">
+        <article class="card roadcard road-right" style="top:60%">
           <h3>Re‑train: Warwick MSc</h3>
           <p>Shifted from cool tech to business outcomes. Built models for optimisation (83%), supply chain analytics (81%), and statistics.</p>
-          <img class="roadimg" src="https://placehold.co/140x140/238636/0d1117?text=MSc" alt="MSc" style="top:-14px; right:-14px;" />
+          <img class="roadimg" src="https://placehold.co/140x140/238636/0d1117?text=MSc" alt="MSc" style="top:-14px; left:-14px;" />
         </article>
-        <article class="card roadcard road-left" style="top:88%">
+        <article class="card roadcard road-left" style="top:80%">
           <h3>Leading Change: WMG</h3>
           <p>Team lead for GHG inventory & reporting; cut data‑gathering time ~40%, improved integrity ~25%, and set up a repeatable reporting cycle.</p>
-          <img class="roadimg" src="https://placehold.co/140x140/238636/0d1117?text=WMG" alt="WMG" style="top:-14px; left:-14px;" />
+          <img class="roadimg" src="https://placehold.co/140x140/238636/0d1117?text=WMG" alt="WMG" style="top:-14px; right:-14px;" />
+        </article>
+      </div>
+    </section>
+
+    <!-- ===== Projects ===== -->
+    <section id="projects">
+      <h2 class="reveal">Projects</h2>
+      <div class="grid cards">
+        <article class="card reveal project-card">
+          <h3>MSc Dissertation: Monte Carlo Simulation for Hospital Car Parking</h3>
+          <p class="muted">Simulated parking demand to optimise space allocation and cut patient wait times.</p>
+          <a href="#" class="muted">View on GitHub</a>
+        </article>
+        <article class="card reveal project-card">
+          <h3>Agent AI in Supply Chain Optimisation</h3>
+          <p class="muted">Applied agent-based AI to enhance decision-making and scenario planning in supply chains.</p>
+          <a href="#" class="muted">View on GitHub</a>
+        </article>
+        <article class="card reveal project-card">
+          <h3>Strategy Dashboard</h3>
+          <p class="muted">Built an interactive dashboard to visualise strategic KPIs for data-driven discussions.</p>
+          <a href="#" class="muted">View on GitHub</a>
         </article>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a Projects navigation link
- introduce Projects section with cards for Monte Carlo car parking simulation, agent AI supply chain optimisation, and strategy dashboard visualisation
- increase roadmap canvas height to prevent overlap with Projects section
- align roadmap timeline images and markers with the central line for consistent layout
- include placeholder GitHub links on each project card

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c8a4dd4483248abaa5add7fa296e